### PR TITLE
added option for a custom return url of SCA + code documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,16 +134,18 @@ onPressed: () async {
 The library offers complete support for SCA on iOS and Android.
 It handles all types of SCA, including 3DS, 3DS2, BankID and others.
 It handles SCA by launching the authentication flow in a web browser, and returns the result to the app.
+The `returnUrlForSCA` parameter must match the configuration of your `AndroidManifest.xml` and `Info.plist` as shown in the next steps.
 
 ```dart
-Stripe.init("pk_xxx");
-final clientSecret = await server.createPaymentIntent(Stripe.getReturnUrl());
+Stripe.init("pk_xxx", returnUrlForSCA: "stripesdk://3ds.stripesdk.io");
+final clientSecret = await server.createPaymentIntent(Stripe.instance.getReturnUrl());
 final paymentIntent = await Stripe.instance.confirmPayment(clientSecret, "pm_card_visa");
 ```
 
 ### Android
 
-You need to declare this intent filter in `android/app/src/main/AndroidManifest.xml`:
+You need to declare the following intent filter in `android/app/src/main/AndroidManifest.xml`.
+This example is for the url `stripesdk://3ds.stripesdk.io`:
 
 ```xml
 <manifest ...>
@@ -168,9 +170,8 @@ You need to declare this intent filter in `android/app/src/main/AndroidManifest.
 
 ### IOS
 
-For iOS you need to declare the scheme in
-`ios/Runner/Info.plist` (or through Xcode's Target Info editor,
-under URL Types):
+For iOS you need to declare the scheme in `ios/Runner/Info.plist` (or through Xcode's Target Info editor,
+under URL Types). This example is for the url `stripesdk://3ds.stripesdk.io`:
 
 ```xml
 <!-- ... other tags -->

--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ This example is for the url `stripesdk://3ds.stripesdk.io`:
   <!-- ... other tags -->
   <application ...>
     <activity ...>
+    
+      android:launchMode="singleTask"
+      <!-- When the launchMode key is set to "singleTask" Android will use the existing instance if possible or open a new one when needed.
+      This fixes the problem that the app will not restart if Firefox was used for the authorization process. -->
+      
       <!-- ... other tags -->
 
       <!-- Deep Links -->

--- a/example/main.dart
+++ b/example/main.dart
@@ -32,7 +32,7 @@ Future<String> _fetchEphemeralKeyFromMyServer(String apiVersion) {
 exampleConfirmPayment() async {
   Stripe.init(publishableKey);
   final paymentIntentClientSecret =
-      await _createPaymentIntent(Stripe.getReturnUrl());
+      await _createPaymentIntent(Stripe.instance.getReturnUrl());
   final paymentIntent = await Stripe.instance
       .confirmPayment(paymentIntentClientSecret, "pm-paymentMethod");
   if (paymentIntent['status'] == 'success') {
@@ -54,7 +54,7 @@ Future<String> _createPaymentIntent(String returnUrl) {
 exampleAuthenticatePayment() async {
   Stripe.init(publishableKey);
   final paymentIntentClientSecret =
-      await _createAndConfirmPaymentIntent(Stripe.getReturnUrl());
+      await _createAndConfirmPaymentIntent(Stripe.instance.getReturnUrl());
   final paymentIntent =
       await Stripe.instance.authenticatePayment(paymentIntentClientSecret);
   if (paymentIntent['status'] == "success") {

--- a/lib/src/stripe.dart
+++ b/lib/src/stripe.dart
@@ -7,14 +7,28 @@ import 'package:url_launcher/url_launcher.dart';
 import 'stripe_api.dart';
 
 class Stripe {
-  Stripe(String publishableKey, {String stripeAccount, String returnUrlFor3ds})
+  /// Creates a new [Stripe] object. Use this constructor if you wish to handle the instance of this class by yourself.
+  /// If not, call [Stripe.init] to create an singleton and use [Stripe.instance] instead.
+  ///
+  /// [publishableKey] is your publishable key, beginning with "sk_".
+  /// Your can copy your key from https://dashboard.stripe.com/account/apikeys
+  ///
+  /// [stripeAccount] is the id of a stripe customer and stats with "cus_".
+  /// This is a optional parameter.
+  ///
+  /// [returnUrlForSCA] can be used to use your own return url for
+  /// Strong Customer Authentication (SCA) such as 3DS, 3DS2, BankID and others.
+  /// It is recommended to use your own app specific url scheme and host.
+  Stripe(String publishableKey, {String stripeAccount, String returnUrlForSCA})
       : _stripeApi = StripeApi(publishableKey, stripeAccount: stripeAccount),
-        _returnUrlFor3ds = returnUrlFor3ds ?? "stripesdk://3ds.stripesdk.io";
+        _returnUrlForSCA = returnUrlForSCA ?? "stripesdk://3ds.stripesdk.io";
 
   final StripeApi _stripeApi;
-  final String _returnUrlFor3ds;
+  final String _returnUrlForSCA;
   static Stripe _instance;
 
+  /// Access the instance of Stripe by calling [Stripe.instance].
+  /// Throws an [Exception] if [Stripe.init] hasn't been called previously.
   static Stripe get instance {
     if (_instance == null) {
       throw Exception(
@@ -23,17 +37,31 @@ class Stripe {
     return _instance;
   }
 
-  static void init(String publishableKey, {String stripeAccount, String returnUrlFor3ds}) {
+  /// Initializes the singleton instance of [Stripe]. Afterwards you can
+  /// use [Stripe.instance] to access the created instance.
+  ///
+  /// [publishableKey] is your publishable key, beginning with "sk_".
+  /// Your can copy your key from https://dashboard.stripe.com/account/apikeys
+  ///
+  /// [stripeAccount] is the id of a stripe customer and stats with "cus_".
+  /// This is a optional parameter.
+  ///
+  /// [returnUrlForSCA] can be used to use your own return url for
+  /// Strong Customer Authentication (SCA) such as 3DS, 3DS2, BankID and others.
+  /// It is recommended to use your own app specific url scheme and host. This
+  /// parameter must match your "android/app/src/main/AndroidManifest.xml"
+  /// and "ios/Runner/Info.plist" configuration.
+  static void init(String publishableKey, {String stripeAccount, String returnUrlForSCA}) {
     _instance = Stripe(publishableKey,
         stripeAccount: stripeAccount,
-        returnUrlFor3ds: returnUrlFor3ds);
+        returnUrlForSCA: returnUrlForSCA);
   }
 
   /// Creates a return URL that can be used to authenticate a single PaymentIntent.
   /// This should be set on the intent before attempting to authenticate it.
   String getReturnUrl() {
     final requestId = Random.secure().nextInt(99999999);
-    return "$_returnUrlFor3ds?requestId=$requestId";
+    return "$_returnUrlForSCA?requestId=$requestId";
   }
 
   /// Confirm a SetupIntent

--- a/lib/src/stripe.dart
+++ b/lib/src/stripe.dart
@@ -7,10 +7,12 @@ import 'package:url_launcher/url_launcher.dart';
 import 'stripe_api.dart';
 
 class Stripe {
-  Stripe(String publishableKey, {String stripeAccount})
-      : _stripeApi = StripeApi(publishableKey, stripeAccount: stripeAccount);
+  Stripe(String publishableKey, {String stripeAccount, String returnUrlFor3ds})
+      : _stripeApi = StripeApi(publishableKey, stripeAccount: stripeAccount),
+        _returnUrlFor3ds = returnUrlFor3ds ?? "stripesdk://3ds.stripesdk.io";
 
   final StripeApi _stripeApi;
+  final String _returnUrlFor3ds;
   static Stripe _instance;
 
   static Stripe get instance {
@@ -21,15 +23,17 @@ class Stripe {
     return _instance;
   }
 
-  static void init(String publishableKey, {String stripeAccount}) {
-    _instance = Stripe(publishableKey, stripeAccount: stripeAccount);
+  static void init(String publishableKey, {String stripeAccount, String returnUrlFor3ds}) {
+    _instance = Stripe(publishableKey,
+        stripeAccount: stripeAccount,
+        returnUrlFor3ds: returnUrlFor3ds);
   }
 
   /// Creates a return URL that can be used to authenticate a single PaymentIntent.
   /// This should be set on the intent before attempting to authenticate it.
-  static String getReturnUrl() {
+  String getReturnUrl() {
     final requestId = Random.secure().nextInt(99999999);
-    return "stripesdk://3ds.stripesdk.io?requestId=$requestId";
+    return "$_returnUrlFor3ds?requestId=$requestId";
   }
 
   /// Confirm a SetupIntent

--- a/lib/src/stripe_api.dart
+++ b/lib/src/stripe_api.dart
@@ -14,6 +14,13 @@ class StripeApi {
   final String apiVersion;
 
   /// Create a new instance, which can be used with e.g. dependency injection.
+  /// Throws a [Exception] if an invalid [publishableKey] has been submitted.
+  ///
+  /// [publishableKey] is your publishable key, beginning with "sk_".
+  /// Your can copy your key from https://dashboard.stripe.com/account/apikeys
+  ///
+  /// [stripeAccount] is the id of a stripe customer and stats with "cus_".
+  /// This is a optional parameter.
   StripeApi(this.publishableKey,
       {this.apiVersion = DEFAULT_API_VERSION, String stripeAccount})
       : _apiHandler = StripeApiHandler(stripeAccount: stripeAccount) {
@@ -21,7 +28,14 @@ class StripeApi {
     _apiHandler.apiVersion = apiVersion;
   }
 
-  /// Initialize the managed singleton instance.
+  /// Initialize the managed singleton instance of [StripeApi].
+  /// Afterwards you can use [StripeApi.instance] to access the created instance.
+  ///
+  /// [publishableKey] is your publishable key, beginning with "sk_".
+  /// Your can copy your key from https://dashboard.stripe.com/account/apikeys
+  ///
+  /// [stripeAccount] is the id of a stripe customer and stats with "cus_".
+  /// This is a optional parameter.
   static void init(String publishableKey,
       {String apiVersion = DEFAULT_API_VERSION, String stripeAccount}) {
     if (_instance == null) {
@@ -30,6 +44,8 @@ class StripeApi {
     }
   }
 
+  /// Access the singleton instance of [StripeApi].
+  /// Throws an [Exception] if [StripeApi.init] hasn't been called previously.
   static StripeApi get instance {
     if (_instance == null) {
       throw Exception(
@@ -112,6 +128,8 @@ class StripeApi {
         params: params);
   }
 
+  /// Validates the received [publishableKey] and throws a [Exception] if an
+  /// invalid key has been submitted.
   static void _validateKey(String publishableKey) {
     if (publishableKey == null || publishableKey.isEmpty) {
       throw Exception("Invalid Publishable Key: " +


### PR DESCRIPTION
As @Isakdl has already taken up in https://github.com/ezet/stripe-sdk/issues/19, a freely selectable return url would be good for SCA payments.

This pull request includes the possibility to use your own result url by using the optional parameter `returnUrlForSCA`. If this parameter is not set, the previous `stripesdk://3ds.stripesdk.io` is used to avoid interfering with already finished applications.

Additionally I have added some code documentation and updated ReadMe.me.