### PR TITLE
Fixed check if expiry month has passed or not

### DIFF
--- a/lib/src/util/model_utils.dart
+++ b/lib/src/util/model_utils.dart
@@ -21,8 +21,8 @@ class ModelUtils {
       return true;
     }
 
-    // Expires at end of specified month, Calendar month starts at 0
-    return normalizeYear(year, now) == now.year && month < (now.month + 1);
+    // Expires at end of specified month
+    return normalizeYear(year, now) == now.year && month < now.month;
   }
 
   /// Determines whether or not the input year has already passed.


### PR DESCRIPTION
The check if the expiry month has passed or not assumes that month property on DateTime ranges from 0..11. This is incorrect. The range is 1..12.

https://api.dart.dev/stable/2.8.1/dart-core/DateTime-class.html