### PR TITLE
fixing issue "credit_card_validator has broken stripe-sdk #111",

### DIFF
--- a/lib/src/models/card.dart
+++ b/lib/src/models/card.dart
@@ -41,7 +41,7 @@ class StripeCard {
   bool validateDate() {
     return _ccValidator
         .validateExpDate(
-            '${expMonth.toString().padLeft(2, '0')}/${expYear.toString().padLeft(2, '0')}')
+        '${expMonth.toString().padLeft(2, '0')}/${expYear.toString().padLeft(2, '0')}')
         .isValid;
   }
 
@@ -50,12 +50,7 @@ class StripeCard {
   /// @return {@code true} if valid, {@code false} otherwise
   bool validateCVC() {
     if (cvc == null) return false;
-    if (number != null) {
-      final cardType = _ccValidator.validateCCNum(number).ccType;
-      return _ccValidator.validateCVV(cvc, cardType: cardType).isValid;
-    } else {
-      return _ccValidator.validateCVV(cvc).isValid;
-    }
+    return _ccValidator.validateCVV(cvc, _ccValidator.validateCCNum(number).ccType).isValid;
   }
 
   /// Returns a stripe hash that represents this card.


### PR DESCRIPTION
we eliminated the validation of the cvc only, if needed we can put a simple number and maxChar validation inline.

there was a problem with the plugin credit_card_validator-1.2.0, on the number of function arguments.