### PR TITLE
Fixed iOS keyboard not becoming NumberPad in Card Number Form field

### DIFF
--- a/lib/src/ui/widgets/card_number_form_field.dart
+++ b/lib/src/ui/widgets/card_number_form_field.dart
@@ -49,7 +49,6 @@ class _CardNumberFormFieldState extends State<CardNumberFormField> {
       controller: widget.textEditingController,
       inputFormatters: [maskFormatter],
       autofocus: true,
-      autofillHints: [AutofillHints.creditCardNumber],
       onSaved: widget.onSaved,
       validator: widget.validator,
       onChanged: widget.onChanged,


### PR DESCRIPTION
There seems to be a bug in Flutter that `keyboardType: TextInputType.number` is currently disabled when `autofillHints: [AutofillHints.creditCardNumber]` is specified.
The keyboard is not fixed to NumberPad and can be switched.

If you remove `keyboardType: TextInputType.number`, `keyboardType: TextInputType.number` is enabled and the keyboard is now number-only as expected.

The `autofillHints: [AutofillHints.creditCardNumber]` seems to have been added when the TextFormField was added to PostalCode.

If you have any other workarounds, please let me know, but currently removing `AutofillHints.creditCardNumber` seems to be the easiest solution.

The issue was confirmed on Flutter 2.0.6, iOS14.5 | 15 Beta.

## Related Issues

TextField 'keyboardType: TextInputType.number' doesn't bring the number keyboard
https://github.com/flutter/flutter/issues/58510

## Screenshot
Before
<img src="https://user-images.githubusercontent.com/8737743/122308474-68a1e480-cf47-11eb-96a2-0bbac10b9ac4.PNG" width="320" />

After
<img src="https://user-images.githubusercontent.com/8737743/122308487-6f305c00-cf47-11eb-98fb-f0589183bc90.PNG" width="320" />