### PR TITLE
fix_for_loader_when_paying_by_bank_cards

### DIFF
--- a/lib/src/ui/checkout_page.dart
+++ b/lib/src/ui/checkout_page.dart
@@ -94,16 +94,19 @@ class _CheckoutPageState extends State<CheckoutPage> {
   void Function() _createAttemptPaymentFunction(BuildContext context, Future<IntentClientSecret> paymentIntentFuture) {
     return () async {
       showProgressDialog(context);
-      final initialPaymentIntent = await paymentIntentFuture.whenComplete(() => hideProgressDialog(context));
+      final initialPaymentIntent = await paymentIntentFuture;
       try {
         final confirmedPaymentIntent = await Stripe.instance
             .confirmPayment(initialPaymentIntent.clientSecret, context, paymentMethodId: _selectedPaymentMethod);
         if (confirmedPaymentIntent['status'] == 'succeeded') {
           widget.onPaymentSuccess(context, confirmedPaymentIntent);
+          hideProgressDialog(context);
         } else {
           widget.onPaymentFailed(context, confirmedPaymentIntent);
+          hideProgressDialog(context);
         }
       } catch (e) {
+        hideProgressDialog(context);
         debugPrint(e.toString());
         if (e is StripeApiException) {
           widget.onPaymentError(context, e);

--- a/lib/src/ui/checkout_page.dart
+++ b/lib/src/ui/checkout_page.dart
@@ -94,7 +94,10 @@ class _CheckoutPageState extends State<CheckoutPage> {
   void Function() _createAttemptPaymentFunction(BuildContext context, Future<IntentClientSecret> paymentIntentFuture) {
     return () async {
       showProgressDialog(context);
-      final initialPaymentIntent = await paymentIntentFuture;
+      final initialPaymentIntent = await paymentIntentFuture.catchError((error){
+        debugPrint(error.toString());
+        hideProgressDialog(context);
+      });
       try {
         final confirmedPaymentIntent = await Stripe.instance
             .confirmPayment(initialPaymentIntent.clientSecret, context, paymentMethodId: _selectedPaymentMethod);

--- a/lib/src/ui/checkout_page.dart
+++ b/lib/src/ui/checkout_page.dart
@@ -95,7 +95,6 @@ class _CheckoutPageState extends State<CheckoutPage> {
     return () async {
       showProgressDialog(context);
       final initialPaymentIntent = await paymentIntentFuture.catchError((error){
-        debugPrint(error.toString());
         hideProgressDialog(context);
       });
       try {


### PR DESCRIPTION
Fix for the loader when trying to pay by using saved bank cards. 

In the current implementation loader is not displayed and it confuses users.